### PR TITLE
For upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+all:
+	g++ -o ARMv6m_Simulator -I./inc/ src/*

--- a/inc/Instruction.h
+++ b/inc/Instruction.h
@@ -29,7 +29,7 @@ public :
 
     void decode();
 
-    void instName(char* name);
+    void instName(const char* name);
     char* getInstName();
 private :
     static Instruction instInst;

--- a/inc/Memory.h
+++ b/inc/Memory.h
@@ -41,8 +41,8 @@ private :
     static Memory memInst;
 
     uint8_t mem[MEM_MAXSIZE];
-    char* dumpFileName;
-    char* instFileName;
+    const char* dumpFileName;
+    const char* instFileName;
 };
 
 #endif /* INC_MEMORY_H_ */

--- a/src/Instruction.cpp
+++ b/src/Instruction.cpp
@@ -1442,7 +1442,7 @@ void Instruction::push_mult(uint16_t inst)
     uint16_t m = (inst >> 8) & 0x01;
 
     uint16_t stack_data_list = (m << 14) | register_list;
-    uint8_t addr = reg->R[SP] - 4*bitCount(stack_data_list);
+    uint32_t addr = reg->R[SP] - 4*bitCount(stack_data_list);
 
     uint8_t i;
     for(i = 0; i < 15; i++)

--- a/src/Instruction.cpp
+++ b/src/Instruction.cpp
@@ -14,7 +14,7 @@ Instruction Instruction::instInst;
 static Memory* mem = Memory::getInstance();
 static Register* reg = Register::getInstance();
 
-void Instruction::instName(char* name)
+void Instruction::instName(const char* name)
 {
     strncpy(currentInst, name, 20);
 }


### PR DESCRIPTION
For your consideration, the following commits address the following:

  - warning-free compilation on gcc version 6.3.1 20170306 (GCC)
  - add a basic Makefile to ease compilation (tested on a Linux box)
  - change an inconsistent pointer type for `addr` (useful for a future relocation feature that I am currently working on, but it doesn't hurt to have this fixed for consistency anyway)

Thanks