### PR TITLE
fix wrong "ADR" test, uncomment passed test

### DIFF
--- a/tests/adrInstrTest.cpp
+++ b/tests/adrInstrTest.cpp
@@ -38,10 +38,10 @@ void test_adrHighesttRegisterWithSmallestOffset()
 {
     printf (" %s \n", __FUNCTION__);
     setInitialRegisterValues();
-    setRegisterValue(PC, INITIAL_PC + 2);
     // Emit UNDEFINED 16-bit instruction.
     emitInstruction16("1101111000000000");
     // Emit actual test instruction at a 2-byte aligned address which isn't 4-byte aligned.
     emitInstruction16("10100dddiiiiiiii", R3, 0);
+    setRegisterValue(PC, INITIAL_PC + 2);
     setExpectedRegisterValue(R3, INITIAL_PC + 4);
 }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -71,7 +71,7 @@ int main()
 
     test_adrLowestRegisterWithLargestOffset();
     test_adrHighesttRegisterWithSmallestOffset();
-    //test_adrpcWillNeedToBeWordAlignedBeforeAdd();
+    test_adrpcWillNeedToBeWordAlignedBeforeAdd();
 
     test_andRegisterUseLowestRegisterForBothArgs();
     test_andRegisterUseHighestRegisterForBothArgs();


### PR DESCRIPTION
In original source of "test_adrpcWillNeedToBeWordAlignedBeforeAdd" is

```cpp
TEST(adr, pcWillNeedToBeWordAlignedBeforeAdd)
{
    // Emit UNDEFINED 16-bit instruction.
    emitInstruction16("1101111000000000");
    // Emit actual test instruction at a 2-byte aligned address which isn't 4-byte aligned.
    emitInstruction16("10100dddiiiiiiii", R3, 0);
    setRegisterValue(PC, INITIAL_PC + 2);
    setExpectedRegisterValue(R3, INITIAL_PC + 4);
    pinkySimStep(&m_context);
}
```

The location where this is executed is incorrect, unlike the original.
```cpp
SetRegisterValue (PC, INITIAL_PC + 2);
```

```cpp
 void test_adrpcWillNeedToBeWordAlignedBeforeAdd()
{
    printf (" %s \n", __FUNCTION__);
    setInitialRegisterValues();
    // setRegisterValue(PC, INITIAL_PC + 2); not this location
    // Emit UNDEFINED 16-bit instruction.
    emitInstruction16("1101111000000000");
    // Emit actual test instruction at a 2-byte aligned address which isn't 4-byte aligned.
    emitInstruction16("10100dddiiiiiiii", R3, 0);
    setRegisterValue(PC, INITIAL_PC + 2); //this location is correct 
    setExpectedRegisterValue(R3, INITIAL_PC + 4);
}
```

and, If the modified test is done, the adr instruction test passes.